### PR TITLE
Implicit subject - use class as subject in the rspec describe

### DIFF
--- a/spec/implicit_subject.rb
+++ b/spec/implicit_subject.rb
@@ -1,0 +1,21 @@
+# Reducing boilerplate codes
+
+RSpec.describe Hash do 
+	# let(:my_hash) { {} }
+	# let(:subject) { Hash.new }
+	it 'should start off empty' do
+		# puts subject
+		# puts subject.class
+		# subject['s'] = 1
+		expect(subject.length).to eq(0)
+		subject['key'] = 'value'
+		puts subject
+		expect(subject.length).to eq(1)
+	end
+
+	it 'is isolated between examples' do
+		puts subject.length
+		expect(subject.length).to eq(0)
+	end
+
+end


### PR DESCRIPTION
Implicit subject - use class as subject in the RSpec describe.

<img width="1115" alt="Screenshot 2024-06-09 at 12 01 19 PM" src="https://github.com/surenthvignesh/rspec-course/assets/7328351/05df1e91-cc8c-44d6-b9d9-2ad896965d0a">
